### PR TITLE
Revert "Fix highlight/bookmark/TOC navigation when ViewPager2 is active"

### DIFF
--- a/app/src/main/java/com/rifters/ebookreader/ViewerActivity.kt
+++ b/app/src/main/java/com/rifters/ebookreader/ViewerActivity.kt
@@ -3169,12 +3169,7 @@ class ViewerActivity : AppCompatActivity(), TextToSpeech.OnInitListener {
             // For PDF files, navigate to the highlighted page
             if (highlight.page in 0 until totalPdfPages) {
                 currentPage = highlight.page
-                // Check if using ViewPager2 for navigation
-                if (isUsingViewPager && binding.viewPager.visibility == View.VISIBLE) {
-                    binding.viewPager.setCurrentItem(currentPage, false)
-                } else {
-                    renderPdfPage(currentPage)
-                }
+                renderPdfPage(currentPage)
                 Toast.makeText(
                     this,
                     getString(R.string.page_format, highlight.page + 1),
@@ -3187,12 +3182,7 @@ class ViewerActivity : AppCompatActivity(), TextToSpeech.OnInitListener {
             // For comic books (CBZ/CBR), navigate to the highlighted page
             if (highlight.page in 0 until totalComicPages) {
                 currentPage = highlight.page
-                // Check if using ViewPager2 for navigation
-                if (isUsingViewPager && binding.viewPager.visibility == View.VISIBLE) {
-                    binding.viewPager.setCurrentItem(currentPage, false)
-                } else {
-                    renderComicPage(currentPage)
-                }
+                renderComicPage(currentPage)
                 Toast.makeText(
                     this,
                     getString(R.string.page_format, highlight.page + 1),
@@ -3248,12 +3238,7 @@ class ViewerActivity : AppCompatActivity(), TextToSpeech.OnInitListener {
             // For PDF files, navigate to the bookmarked page
             if (bookmark.page in 0 until totalPdfPages) {
                 currentPage = bookmark.page
-                // Check if using ViewPager2 for navigation
-                if (isUsingViewPager && binding.viewPager.visibility == View.VISIBLE) {
-                    binding.viewPager.setCurrentItem(currentPage, false)
-                } else {
-                    renderPdfPage(currentPage)
-                }
+                renderPdfPage(currentPage)
                 Toast.makeText(
                     this,
                     getString(R.string.page_format, bookmark.page + 1),
@@ -3266,12 +3251,7 @@ class ViewerActivity : AppCompatActivity(), TextToSpeech.OnInitListener {
             // For comic books (CBZ/CBR), navigate to the bookmarked page
             if (bookmark.page in 0 until totalComicPages) {
                 currentPage = bookmark.page
-                // Check if using ViewPager2 for navigation
-                if (isUsingViewPager && binding.viewPager.visibility == View.VISIBLE) {
-                    binding.viewPager.setCurrentItem(currentPage, false)
-                } else {
-                    renderComicPage(currentPage)
-                }
+                renderComicPage(currentPage)
                 Toast.makeText(
                     this,
                     getString(R.string.page_format, bookmark.page + 1),
@@ -3337,12 +3317,7 @@ class ViewerActivity : AppCompatActivity(), TextToSpeech.OnInitListener {
             // For PDF files, navigate to the page
             if (tocItem.page in 0 until totalPdfPages) {
                 currentPage = tocItem.page
-                // Check if using ViewPager2 for navigation
-                if (isUsingViewPager && binding.viewPager.visibility == View.VISIBLE) {
-                    binding.viewPager.setCurrentItem(currentPage, false)
-                } else {
-                    renderPdfPage(currentPage)
-                }
+                renderPdfPage(currentPage)
                 Toast.makeText(
                     this,
                     getString(R.string.page_format, tocItem.page + 1),


### PR DESCRIPTION
Reverts rifters/ebook-reader-android#88

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Simplifies navigation for highlights, bookmarks, and TOC by bypassing ViewPager2 and directly rendering PDF/comic pages.
> 
> - **Navigation (ViewerActivity.kt)**:
>   - `navigateToHighlight` and `navigateToTocItem`: remove ViewPager2 checks; always call `renderPdfPage(...)`/`renderComicPage(...)` for PDFs/comics.
>   - `navigateToBookmark`: drop per-format ViewPager2 setCurrentItem path inside PDF/comic branches; now uses `renderPdfPage(...)`/`renderComicPage(...)` after setting `currentPage`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f71a4e07c06a0041fa53be1dc459df8fe8eabdf9. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->