### PR TITLE
Revert "Fix bookmark navigation when ViewPager2 is active"

### DIFF
--- a/app/src/main/java/com/rifters/ebookreader/ViewerActivity.kt
+++ b/app/src/main/java/com/rifters/ebookreader/ViewerActivity.kt
@@ -3222,19 +3222,7 @@ class ViewerActivity : AppCompatActivity(), TextToSpeech.OnInitListener {
     }
     
     private fun navigateToBookmark(bookmark: Bookmark) {
-        if (isUsingViewPager && binding.viewPager.visibility == View.VISIBLE) {
-            // Use ViewPager2 navigation for PDFs and comic books
-            if (bookmark.page in 0 until (binding.viewPager.adapter?.itemCount ?: 0)) {
-                binding.viewPager.setCurrentItem(bookmark.page, true)
-                Toast.makeText(
-                    this,
-                    getString(R.string.page_format, bookmark.page + 1),
-                    Toast.LENGTH_SHORT
-                ).show()
-            } else {
-                Toast.makeText(this, "Invalid page number", Toast.LENGTH_SHORT).show()
-            }
-        } else if (pdfRenderer != null && totalPdfPages > 0) {
+        if (pdfRenderer != null && totalPdfPages > 0) {
             // For PDF files, navigate to the bookmarked page
             if (bookmark.page in 0 until totalPdfPages) {
                 currentPage = bookmark.page


### PR DESCRIPTION
Reverts rifters/ebook-reader-android#89

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Removes ViewPager2 handling from bookmark navigation, reverting to format-specific navigation for PDF, comics, and EPUB.
> 
> - **ViewerActivity.kt**:
>   - **Bookmark navigation**:
>     - Removes `ViewPager2` path; no longer calls `viewPager.setCurrentItem`.
>     - PDFs: navigate via `pdfRenderer` (`renderPdfPage`).
>     - Comics: navigate via `renderComicPage` using `totalComicPages`.
>     - EPUB: navigate by chapter and position using `renderEpubChapter` with `pendingEpubPageAfterLoad`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 80a2e73e1cc39e38a8d3ca5e08857175f54c5a5d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->